### PR TITLE
Adding link preconnect header for improved performance

### DIFF
--- a/backend/web/.htaccess
+++ b/backend/web/.htaccess
@@ -1,3 +1,8 @@
+# Set precoonect http header
+<ifModule mod_headers.c>
+    Header set link "<//ajax.googleapis.com>; rel=preconnect; crossorigin, <//fonts.googleapis.com>; rel=preconnect; crossorigin, <//fonts.gstatic.com>; rel=preconnect; crossorigin"
+</ifModule>
+
 # Cache JavaScript files for 1 day
 <filesMatch ".(js)$">
     Header set Cache-Control "max-age=86400, public"


### PR DESCRIPTION
Retromat is making use of several assets from 3rd-party hosts. These assets can be requested faster if link preconnect is applied because it does the DNS resolution, TCP connection and TLS Handshake ahead of time so that when the assets get requested within the HTML, the HTTP connection is already fully established.

Here's more info on link preconnect:
https://caniuse.com/#feat=link-rel-preconnect
https://www.igvita.com/2015/08/17/eliminating-roundtrips-with-preconnect/
https://github.com/GoogleChrome/lighthouse/issues/3106

I've made use of the .htaccess file to implement this because this seems to be the easiest way to change Apache server config settings on Uberspace. See: https://wiki.uberspace.de/webserver:htaccess