### PR TITLE
Enable GZIP compression for static assets for better performance

### DIFF
--- a/backend/web/.htaccess
+++ b/backend/web/.htaccess
@@ -8,6 +8,9 @@
     Header set Cache-Control "max-age=2592000, public"
 </filesMatch>
 
+# Enable GZIP compression for plaintext assets
+AddOutputFilterByType DEFLATE text/html text/plain text/xml image/svg+xml text/css application/javascript text/javascript application/json
+
 # Use the front controller as index file. It serves as a fallback solution when
 # every other rewrite/redirect fails (e.g. in an aliased environment without
 # mod_rewrite). Additionally, this reduces the matching process for the


### PR DESCRIPTION
Several plain text assets are currently not being served gzipped by the Uberspace server. See this table from WebPagetest:

> Use gzip compression for transferring compressable responses: 40/100
> 
> 279.2 KB total in compressible text, target size = 109.7 KB - potential savings = 169.5 KB
> 
> FAILED - (111.2 KB, compressed = 35.1 KB - savings of 76.1 KB) - https://plans-for-retrospectives.com/activities.json?locale=en
> FAILED - (61.8 KB, compressed = 21.1 KB - savings of 40.7 KB) - https://plans-for-retrospectives.com/piwik/piwik.js
> FAILED - (18.4 KB, compressed = 5.2 KB - savings of 13.2 KB) - https://plans-for-retrospectives.com/en/
> FAILED - (13.9 KB, compressed = 3.6 KB - savings of 10.3 KB) - https://plans-for-retrospectives.com/static/functions.js
> FAILED - (11.4 KB, compressed = 2.7 KB - savings of 8.7 KB) - https://plans-for-retrospectives.com/static/lightbox/lightbox.js
> FAILED - (11.4 KB, compressed = 3.1 KB - savings of 8.3 KB) - https://plans-for-retrospectives.com/static/retromat.css
> FAILED - (9.2 KB, compressed = 2.5 KB - savings of 6.7 KB) - https://plans-for-retrospectives.com/static/lang/photos.js
> FAILED - (4.5 KB, compressed = 1.6 KB - savings of 2.9 KB) - https://plans-for-retrospectives.com/static/images/icons.svg
> FAILED - (3.7 KB, compressed = 1.1 KB - savings of 2.6 KB) - https://plans-for-retrospectives.com/static/lightbox/lightbox.css

By adding "AddOutputFilterByType DEFLATE" followed by the desired mime types, we can enable GZIP compression for those assets on Uberspace. See this Uberspace Wiki entry on compression: https://wiki.uberspace.de/webserver:htaccess#kompression