### PR TITLE
Adding custom Keep-Alive settings to htaccess

### DIFF
--- a/backend/web/.htaccess
+++ b/backend/web/.htaccess
@@ -1,6 +1,8 @@
 # Set precoonect http header
 <ifModule mod_headers.c>
     Header set link "<//ajax.googleapis.com>; rel=preconnect; crossorigin, <//fonts.googleapis.com>; rel=preconnect; crossorigin, <//fonts.gstatic.com>; rel=preconnect; crossorigin"
+    Header set Connection keep-alive
+    Header set Keep-Alive timeout=301,max=500
 </ifModule>
 
 # Cache JavaScript files for 1 day


### PR DESCRIPTION
Now that Keep-Alive is active thanks to @fiddike + Uberspace, we can (hopefully! Unless Uberspace prevents this ...) take control of the Keep-Alive settings. With this htaccess change, the settings are now changed to keep TCP connections open for 301 seconds and allow up to 500 requests per connection before it has to be closed+re-established. This should make the Keep-Alive settings more performant and help once a CDN becomes part of the mix for Retromat.
